### PR TITLE
Add rimraft to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "node-sass": "^3.7.0",
     "react-addons-test-utils": "^15.0.2",
     "react-hot-loader": "^1.3.0",
+    "rimraf": "^2.6.1",
     "sass-loader": "^3.2.0",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",


### PR DESCRIPTION
Build script was failing because rimraft was not found

sh: rimraf: command not found